### PR TITLE
Add register example for symfony 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Specifying HtmlMin is needed for the autowiring.
             - { name: HtmlMin }
 
     voku\twig\MinifyHtmlExtension:
+        arguments:
+            $forceCompression: false
         tags:
             - { name: twig.extension }
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ $minifier = new HtmlMin();
 $twig->addExtension(new MinifyHtmlExtension($minifier));
 ```
 
+### Register extension in symfony 4
+Specifying HtmlMin is needed for the autowiring.
+
+```yaml
+    voku\helper\HtmlMin:
+        tags:
+            - { name: HtmlMin }
+
+    voku\twig\MinifyHtmlExtension:
+        tags:
+            - { name: twig.extension }
+```
+
 Then use it in your templates:
 
 ```


### PR DESCRIPTION
**Fixes** # Example how to register this Twig extension in symfony 4

NB When force minifying on development, the symfony debug bar stops working (it is injected though). Can you look into that?