### PR TITLE
Upgrade code to work in PHP8 or greater and/or Laravel 9 or greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,23 @@ composer require voku/html-compress-twig
 First register the extension with Twig:
 
 ```php
-use voku\helper\HtmlMin;
-use voku\twig\MinifyHtmlExtension;
+use Voku\Helper\HtmlMin;
+use Voku\Twig\MinifyHtmlExtension;
 
 $twig = new \Twig\Environment($loader);
 $minifier = new HtmlMin();
 $twig->addExtension(new MinifyHtmlExtension($minifier));
 ```
 
-### Register extension in symfony 4
+### Register extension in symfony 5
 Specifying HtmlMin is needed for the autowiring.
 
 ```yaml
-    voku\helper\HtmlMin:
+    Voku\Helper\HtmlMin:
         tags:
             - { name: HtmlMin }
 
-    voku\twig\MinifyHtmlExtension:
+    Voku\Twig\MinifyHtmlExtension:
         arguments:
             $forceCompression: false
         tags:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0.0",
+    "php": "^8.0 || ^8.1 || ^8.2",
     "twig/twig": "~2.7 || ^3",
     "voku/html-min": "~4.4",
     "voku/simple-cache": "~4.0"
@@ -31,7 +31,7 @@
   },
   "autoload": {
     "psr-4": {
-      "voku\\": "src/voku/"
+      "Voku\\": "src/voku/"
     }
   }
 }

--- a/src/voku/twig/MinifyHtmlExtension.php
+++ b/src/voku/twig/MinifyHtmlExtension.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace voku\twig;
+namespace Voku\Twig;
 
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
-use voku\cache\Cache;
-use voku\helper\HtmlMin;
+use Voku\Cache\Cache;
+use Voku\Helper\HtmlMin;
 
 class MinifyHtmlExtension extends AbstractExtension
 {

--- a/src/voku/twig/MinifyHtmlNode.php
+++ b/src/voku/twig/MinifyHtmlNode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace voku\twig;
+namespace Voku\Twig;
 
 use Twig\Compiler;
 use Twig\Node\Node;
@@ -29,7 +29,7 @@ class MinifyHtmlNode extends Node
             ->addDebugInfo($this)
             ->write("ob_start();\n")
             ->subcompile($this->getNode('body'))
-            ->write('$extension = $this->env->getExtension(\'\\voku\\twig\\MinifyHtmlExtension\');' . "\n")
+            ->write('$extension = $this->env->getExtension(\'\\Voku\\Twig\\MinifyHtmlExtension\');' . "\n")
             ->write('echo $extension->compress($this->env, ob_get_clean());' . "\n");
     }
 }

--- a/src/voku/twig/MinifyHtmlTokenParser.php
+++ b/src/voku/twig/MinifyHtmlTokenParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace voku\twig;
+namespace Voku\Twig;
 
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;


### PR DESCRIPTION
This repo doesn't work in PHP 8, 8.1 or 8.2 due to the namespaces not being Capitalized.

* Have updated the namespaces.
* Have updated `composer.json` and removed php 7 as security updates ended in 28 November 2022.
* Have updated readme with new namespaces and Sympony 4 has ended security updates and updated it to v5.

Need to update the connecting repos now.

### Linked to Pull Requests

https://github.com/voku/html-compress-twig/pull/5

https://github.com/voku/HtmlMin/pull/85

https://github.com/voku/simple_html_dom/pull/95

https://github.com/voku/simple-cache/pull/30

https://github.com/voku/portable-ascii/pull/87

### Tested on the following

Tested on PHP 8.2 and Laravel 9.1
